### PR TITLE
Fix String equality check

### DIFF
--- a/approve-authorization/server/java/src/main/java/com/stripe/sample/Server.java
+++ b/approve-authorization/server/java/src/main/java/com/stripe/sample/Server.java
@@ -45,7 +45,7 @@ public class Server {
         return "";
       }
 
-      if (event.getType() == "issuing_authorization.request") {
+      if (event.getType().equals("issuing_authorization.request")) {
         // Deserialize the nested object inside the event
         EventDataObjectDeserializer dataObjectDeserializer = event.getDataObjectDeserializer();
         if (dataObjectDeserializer.getObject().isPresent()) {


### PR DESCRIPTION
https://docs.oracle.com/javase/specs/jls/se7/html/jls-15.html#jls-15.21

See last line

> 15.21.3. Reference Equality Operators == and !=
> 
> If the operands of an equality operator are both of either reference type or the null type, then the operation is object equality.
> 
> It is a compile-time error if it is impossible to convert the type of either operand to the type of the other by a casting conversion ([§5.5](https://docs.oracle.com/javase/specs/jls/se7/html/jls-5.html#jls-5.5)). The run-time values of the two operands would necessarily be unequal.
> 
> At run time, the result of == is true if the operand values are both null or both refer to the same object or array; otherwise, the result is false.
> 
> The result of != is false if the operand values are both null or both refer to the same object or array; otherwise, the result is true.
> 
> While == may be used to compare references of type String, such an equality test determines whether or not the two operands refer to the same String object. The result is false if the operands are distinct String objects, even if they contain the same sequence of characters ([§3.10.5](https://docs.oracle.com/javase/specs/jls/se7/html/jls-3.html#jls-3.10.5)). The contents of two strings s and t can be tested for equality by the method invocation s.equals(t).
> 